### PR TITLE
Fixes PHP 8.4 Deprecation

### DIFF
--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -21,7 +21,7 @@ class File implements \JsonSerializable
     protected $filename;
     protected $headers = [];
 
-    public function __construct($contents = null, string $filename = null, string $contentType = null, array $headers = [])
+    public function __construct($contents = null, ?string $filename = null, ?string $contentType = null, array $headers = [])
     {
         $this->contents = $this->resolveContent($contents);
         $this->filename = $filename;


### PR DESCRIPTION
Fixes: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead